### PR TITLE
支持自动贴合通过 snapToTarget 属性指定的外部元素

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw*
+.history
+.vscode

--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@
 ```vue
 <vue-draggable-resizable :snap="true" :snap-tolerance="20" />
 ```
+
+**snapToTarget**<br/>
+类型: `String`<br/>
+必需: `false`<br/>
+默认: `null`
+
+当调用`snap`时，定义组件对齐到其他外部元素。
+
+```vue
+<!-- guide-line 为外部元素样式名 -->
+<vue-draggable-resizable
+  :snap="true"
+  :snap-tolerance="20"
+  snap-to-target="guide-line"
+/>
+```
 ## 新增Events
 **refLineParams**<br/>
 参数: params<br/>

--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -218,7 +218,7 @@ export default {
         return typeof val === 'number'
       }
     },
-    snapToTargets: {
+    snapToTarget: {
       type: String,
       default: null
     },
@@ -721,9 +721,9 @@ export default {
         // 获取当前父节点下所有子节点
         const nodes = Array.from(this.$el.parentNode.childNodes)
 
-        if (this.snapToTargets) {
-          const targets = document.querySelectorAll(this.snapToTargets)
-          if (targets.length) nodes.push(Array.from(targets))
+        if (this.snapToTarget) {
+          const targets = document.querySelectorAll('.' + this.snapToTarget)
+          if (targets.length) nodes.push(...Array.from(targets))
         }
 
         let tem = {
@@ -870,7 +870,8 @@ export default {
       let groupLeft = 0
       let groupTop = 0
       for (let item of nodes) {
-        if (item.className !== undefined && item.className.includes(this.classNameActive)) {
+        const className = item.className
+        if (className !== undefined && (className.includes(this.classNameActive) || className.includes(this.snapToTarget))) {
           activeAll.push(item)
         }
       }

--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -218,6 +218,10 @@ export default {
         return typeof val === 'number'
       }
     },
+    snapToTargets: {
+      type: String,
+      default: null
+    },
     // 缩放比例
     scaleRatio: {
       type: Number,
@@ -715,7 +719,12 @@ export default {
         for (let i in refLine) { refLine[i] = JSON.parse(JSON.stringify(temArr)) }
 
         // 获取当前父节点下所有子节点
-        const nodes = this.$el.parentNode.childNodes
+        const nodes = Array.from(this.$el.parentNode.childNodes)
+
+        if (this.snapToTargets) {
+          const targets = document.querySelectorAll(this.snapToTargets)
+          if (targets.length) nodes.push(Array.from(targets))
+        }
 
         let tem = {
           value: { x: [[], [], []], y: [[], [], []] },

--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -741,7 +741,14 @@ export default {
           activeBottom = groupTop + groupHeight
         }
         for (let item of nodes) {
-          if (item.className !== undefined && !item.className.includes(this.classNameActive) && item.getAttribute('data-is-snap') !== null && item.getAttribute('data-is-snap') !== 'false') {
+          const className = item.className
+          if (className === undefined) continue
+          const snapIgnore = item.getAttribute('data-is-snap')
+          item.isGuideLine = className.includes(this.snapToTarget)
+          if (item.isGuideLine) {
+            item.isVGuideLine = className.includes('line-v')
+          }
+          if (!className.includes(this.classNameActive) && snapIgnore !== null && snapIgnore !== 'false') {
             const w = item.offsetWidth
             const h = item.offsetHeight
             const l = item.offsetLeft // 对齐目标的left
@@ -870,35 +877,17 @@ export default {
       let groupLeft = 0
       let groupTop = 0
       for (let item of nodes) {
-        const className = item.className
-        if (className === undefined) continue;
-        item.isVDRWrapper = className.includes(this.classNameActive)
-        item.isGuideLine = className.includes(this.snapToTarget)
-        if (item.isVDRWrapper || item.isGuideLine) {
-          if (item.isGuideLine) {
-            item.isVGuideLine = className.includes('line-v')
-          }
+        if (item.className !== undefined && item.className.includes(this.classNameActive)) {
           activeAll.push(item)
         }
       }
       const AllLength = activeAll.length
       if (AllLength > 1) {
         for (let i of activeAll) {
-          let l, r, t, b
-          if (i.isVDRWrapper) {
-            l = i.offsetLeft
-            r = l + i.offsetWidth
-            t = i.offsetTop
-            b = t + i.offsetHeight
-          } else if (i.isGuideLine) {
-            if (i.isVGuideLine) {
-              l = r = i.offsetLeft
-              t = b = 0
-            } else {
-              l = r = 0
-              t = b = i.offsetTop
-            }
-          }
+          const l = i.offsetLeft
+          const r = l + i.offsetWidth
+          const t = i.offsetTop
+          const b = t + i.offsetHeight
           XArray.push(t, b)
           YArray.push(l, r)
         }

--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -748,9 +748,16 @@ export default {
           if (item.isGuideLine) {
             item.isVGuideLine = className.includes('line-v')
           }
-          if (!className.includes(this.classNameActive) && snapIgnore !== null && snapIgnore !== 'false') {
-            const w = item.offsetWidth
-            const h = item.offsetHeight
+          if (!className.includes(this.classNameActive) && (snapIgnore !== null || item.isGuideLine) && snapIgnore !== 'false') {
+            let w = item.offsetWidth
+            let h = item.offsetHeight
+            if (item.isGuideLine) {
+              if (item.isVGuideLine) {
+                w = 0
+              } else {
+                h = 0
+              }
+            }
             const l = item.offsetLeft // 对齐目标的left
             const r = l + w // 对齐目标right
             const t = item.offsetTop// 对齐目标的top

--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -194,6 +194,10 @@ export default {
       type: [Boolean, String],
       default: false
     },
+    parentSize: {
+      type: Object,
+      defualt: null
+    },
     onDragStart: {
       type: Function,
       default: null
@@ -943,6 +947,15 @@ export default {
   },
 
   watch: {
+    parentSize: {
+      handler: function (value) {
+        if (value && this.parent) {
+          this.parentWidth = value.width
+          this.parentHeight = value.height
+        }
+      },
+      deep: true
+    },
     active (val) {
       this.enabled = val
 

--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -948,12 +948,7 @@ export default {
 
   watch: {
     parentSize: {
-      handler: function (value) {
-        if (value && this.parent) {
-          this.parentWidth = value.width
-          this.parentHeight = value.height
-        }
-      },
+      handler: 'checkParentSize',
       deep: true
     },
     active (val) {

--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -723,7 +723,7 @@ export default {
 
         if (this.snapToTarget) {
           const targets = document.querySelectorAll('.' + this.snapToTarget)
-          if (targets.length) nodes.push(...Array.from(targets))
+          if (targets.length) nodes.push(...targets)
         }
 
         let tem = {
@@ -871,17 +871,34 @@ export default {
       let groupTop = 0
       for (let item of nodes) {
         const className = item.className
-        if (className !== undefined && (className.includes(this.classNameActive) || className.includes(this.snapToTarget))) {
+        if (className === undefined) continue;
+        item.isVDRWrapper = className.includes(this.classNameActive)
+        item.isGuideLine = className.includes(this.snapToTarget)
+        if (item.isVDRWrapper || item.isGuideLine) {
+          if (item.isGuideLine) {
+            item.isVGuideLine = className.includes('line-v')
+          }
           activeAll.push(item)
         }
       }
       const AllLength = activeAll.length
       if (AllLength > 1) {
         for (let i of activeAll) {
-          const l = i.offsetLeft
-          const r = l + i.offsetWidth
-          const t = i.offsetTop
-          const b = t + i.offsetHeight
+          let l, r, t, b
+          if (i.isVDRWrapper) {
+            l = i.offsetLeft
+            r = l + i.offsetWidth
+            t = i.offsetTop
+            b = t + i.offsetHeight
+          } else if (i.isGuideLine) {
+            if (i.isVGuideLine) {
+              l = r = i.offsetLeft
+              t = b = 0
+            } else {
+              l = r = 0
+              t = b = i.offsetTop
+            }
+          }
           XArray.push(t, b)
           YArray.push(l, r)
         }


### PR DESCRIPTION
因有自动对齐贴合外部参考线、盒子的需求，故增加了 snap-to-target 属性。

**snapToTarget**<br/>
类型: `String`<br/>
必需: `false`<br/>
默认: `null`

当调用`snap`时，定义组件对齐到其他外部元素。

```vue
<!-- guide-line 为外部元素样式名 -->
<vue-draggable-resizable
  :snap="true"
  :snap-tolerance="20"
  snap-to-target="guide-line"
/>
```

注意：本次修改增加了 'line-v' （参考线样式名片段）字符串的判断（line: 749），这个也许是该组件所不需要的，但该判断并不影响功能实现。