### PR TITLE
fix: 移动端选中其他对象不会对之前的对象取消激活状态的问题

### DIFF
--- a/src/components/vue-draggable-resizable.vue
+++ b/src/components/vue-draggable-resizable.vue
@@ -314,12 +314,14 @@ export default {
     // 优化：取消选中的行为优先绑定在父节点上
     const parentElement = this.$el.parentNode
     addEvent(parentElement || document.documentElement, 'mousedown', this.deselect)
+    addEvent(parentElement || document.documentElement, 'touchstart', this.deselect)
     addEvent(parentElement || document.documentElement, 'touchend touchcancel', this.deselect)
 
     addEvent(window, 'resize', this.checkParentSize)
   },
   beforeDestroy: function () {
-    removeEvent(document.documentElement, 'mousedown', this.deselect)
+    removeEvent(document.documentElement, 'mousedown touchstart', this.deselect)
+    removeEvent(document.documentElement, 'touchstart', this.deselect)
     removeEvent(document.documentElement, 'touchstart', this.handleUp)
     removeEvent(document.documentElement, 'mousemove', this.move)
     removeEvent(document.documentElement, 'touchmove', this.move)


### PR DESCRIPTION
在移动端创建多个可拖动的对象，通过拖动激活或一个对象，然后去拖动另一个对象，此时第一个对象的激活状态没有被取消。导致吸附等异常。